### PR TITLE
Fix cron jobs stacking up

### DIFF
--- a/7.0-cli/bin/docker-environment
+++ b/7.0-cli/bin/docker-environment
@@ -68,9 +68,9 @@ chown www-data:www-data $MAGENTO_ROOT
 CRON_LOG=/var/log/cron.log
 
 # Setup Magento cron
-echo "* * * * * www-data /usr/local/bin/php ${MAGENTO_ROOT}/bin/magento cron:run | grep -v \"Ran jobs by schedule\" >> ${MAGENTO_ROOT}/var/log/magento.cron.log" > /etc/cron.d/magento
-echo "* * * * * www-data /usr/local/bin/php ${MAGENTO_ROOT}/update/cron.php >> ${MAGENTO_ROOT}/var/log/update.cron.log" >> /etc/cron.d/magento
-echo "* * * * * www-data /usr/local/bin/php ${MAGENTO_ROOT}/bin/magento setup:cron:run >> ${MAGENTO_ROOT}/var/log/setup.cron.log" >> /etc/cron.d/magento
+echo "* * * * * www-data /usr/bin/flock -n /tmp/cron.lock /usr/local/bin/php ${MAGENTO_ROOT}/bin/magento cron:run | grep -v \"Ran jobs by schedule\" >> ${MAGENTO_ROOT}/var/log/magento.cron.log" > /etc/cron.d/magento
+echo "* * * * * www-data /usr/bin/flock -n /tmp/update.cron.lock /usr/local/bin/php ${MAGENTO_ROOT}/update/cron.php >> ${MAGENTO_ROOT}/var/log/update.cron.log" >> /etc/cron.d/magento
+echo "* * * * * www-data /usr/bin/flock -n /tmp/setup.cron.lock /usr/local/bin/php ${MAGENTO_ROOT}/bin/magento setup:cron:run >> ${MAGENTO_ROOT}/var/log/setup.cron.log" >> /etc/cron.d/magento
 
 # Get rsyslog running for cron output
 touch $CRON_LOG


### PR DESCRIPTION
Uses flock to only run the cron job if a lock on a temp file is open. Skips execution if the process is running, and the lock will open if the cron job completes or is terminated.